### PR TITLE
string::new doesn't take any arguments

### DIFF
--- a/wgpu-core/src/binding_model.rs
+++ b/wgpu-core/src/binding_model.rs
@@ -479,7 +479,7 @@ impl<A: HalApi> Resource<BindGroupLayoutId> for BindGroupLayout<A> {
         #[cfg(debug_assertions)]
         return self.label.clone();
         #[cfg(not(debug_assertions))]
-        return String::new("");
+        return String::new();
     }
 }
 

--- a/wgpu-core/src/pipeline.rs
+++ b/wgpu-core/src/pipeline.rs
@@ -78,7 +78,7 @@ impl<A: HalApi> Resource<ShaderModuleId> for ShaderModule<A> {
         #[cfg(debug_assertions)]
         return self.label.clone();
         #[cfg(not(debug_assertions))]
-        return String::new("");
+        return String::new();
     }
 }
 


### PR DESCRIPTION
I was testing the draft PR, and this is needed to make it run in `--release` mode.