### PR TITLE
Fix usage of active_submission_index.fetch_add

### DIFF
--- a/wgpu-core/src/device/global.rs
+++ b/wgpu-core/src/device/global.rs
@@ -2454,7 +2454,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
                 buffer.info.use_at(
                     device
                         .active_submission_index
-                        .fetch_add(1, Ordering::Relaxed),
+                        .fetch_add(1, Ordering::Relaxed)
+                        + 1,
                 );
                 let region = wgt::BufferSize::new(buffer.size).map(|size| hal::BufferCopy {
                     src_offset: 0,

--- a/wgpu-core/src/device/queue.rs
+++ b/wgpu-core/src/device/queue.rs
@@ -555,7 +555,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         dst.info.use_at(
             device
                 .active_submission_index
-                .fetch_add(1, Ordering::Relaxed),
+                .fetch_add(1, Ordering::Relaxed)
+                + 1,
         );
 
         let region = wgt::BufferSize::new(src_buffer_size).map(|size| hal::BufferCopy {
@@ -769,7 +770,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
         dst.info.use_at(
             device
                 .active_submission_index
-                .fetch_add(1, Ordering::Relaxed),
+                .fetch_add(1, Ordering::Relaxed)
+                + 1,
         );
 
         let dst_raw = dst
@@ -1086,7 +1088,8 @@ impl<G: GlobalIdentityHandlerFactory> Global<G> {
 
             let submit_index = device
                 .active_submission_index
-                .fetch_add(1, Ordering::Relaxed);
+                .fetch_add(1, Ordering::Relaxed)
+                + 1;
             let mut active_executions = Vec::new();
             let mut used_surface_textures = track::TextureUsageScope::new();
             let mut pending_writes = device.pending_writes.lock();


### PR DESCRIPTION
From https://doc.rust-lang.org/std/sync/atomic/struct.AtomicU64.html#method.fetch_add:

> Adds to the current value, returning the previous value.

Thus, receiving the new _active_ submission index after incrementing it requires adding `1` to the return value locally as well.

For comparison, the other uses of `fetch_add` in wgpu (unrelated to the current changes) treat the atomic as a "next id" variable instead of an "active id", thus not requiring to increment the return value of `fetch_add`:

https://github.com/gfx-rs/wgpu/blob/dd64343f942ff519f980a2adc02fa60f3a7b72a3/wgpu/src/backend/web.rs#L29

https://github.com/gfx-rs/wgpu/blob/dd64343f942ff519f980a2adc02fa60f3a7b72a3/wgpu-hal/src/gles/device.rs#L1094